### PR TITLE
Re-raising Future exceptions. Extracted the ComposeEfilesUpdater class to prevent pickling error for the field 'retrieve: RetrieveEfiles'

### DIFF
--- a/composer/efile/compose.py
+++ b/composer/efile/compose.py
@@ -33,35 +33,16 @@ class ComposeEfiles(Callable):
         path_mgr: EINPathManager = EINPathManager(basepath)
         return cls(retrieve, path_mgr)
 
-    def _get_existing(self, ein: str) -> Dict:
-        try:
-            with self.path_mgr.open_for_reading(ein, TEMPLATE) as fh:
-                return json.load(fh)
-        except FileNotFoundError:
-            return {}
-
-    def _do_create_or_update(self, ein: str, updates: Dict[str, str]):
-        composite: Dict = self._get_existing(ein)
-        for period, json_path in updates.items():
-            with open(json_path) as fh:
-                content: Dict = json.load(fh)
-            composite[period] = content
-        with self.path_mgr.open_for_writing(ein, TEMPLATE) as fh:
-            json.dump(composite, fh, indent=2)
-
-    def _create_or_update(self, change: Tuple[str, Dict[str, str]]):
-        ein, updates = change
-        fn: Callable = lambda: self._do_create_or_update(ein, updates)
-        self.t_log.measure(fn)
-
     def use_for_loop(self, json_changes: Iterable[Tuple[str, Dict[str, str]]]):
+        updater = ComposeEfilesUpdater(self.path_mgr)
         for change in json_changes:
-            self._create_or_update(change)
+            updater.create_or_update(change)
 
     def use_process_pool(self, json_changes: Iterable[Tuple[str, Dict[str, str]]]):
+        updater = ComposeEfilesUpdater(self.path_mgr)
         exceptions = []
         with ProcessPoolExecutor() as executor:
-            futures = [executor.submit(self._create_or_update, json_change) for json_change in json_changes]
+            futures = [executor.submit(updater.create_or_update, change) for change in json_changes]
             for future in as_completed(futures):
                 if future.exception() is not None:
                     exceptions.append(future.exception())
@@ -83,3 +64,25 @@ class ComposeEfiles(Callable):
 
         # If I instead use this, it does not work -- seems to deadlock
         self.use_process_pool(json_changes)
+
+
+@dataclass
+class ComposeEfilesUpdater:
+    path_mgr: EINPathManager
+
+    def _get_existing(self, ein: str) -> Dict:
+        try:
+            with self.path_mgr.open_for_reading(ein, TEMPLATE) as fh:
+                return json.load(fh)
+        except FileNotFoundError:
+            return {}
+
+    def create_or_update(self, change: Tuple[str, Dict[str, str]]):
+        ein, updates = change
+        composite: Dict = self._get_existing(ein)
+        for period, json_path in updates.items():
+            with open(json_path) as fh:
+                content: Dict = json.load(fh)
+            composite[period] = content
+        with self.path_mgr.open_for_writing(ein, TEMPLATE) as fh:
+            json.dump(composite, fh, indent=2)


### PR DESCRIPTION
1. Replaced `executor.map` to `executor.submit` - it allows to get possible exceptions and re-raise them. Now the executor doesn't hang.
2. Got exception `_pickle.PicklingError: args[0] from __newobj__ args has the wrong class` - it seems, the filed `retrieve: RetrieveEfiles` can't be picked to send the Composite instance (self) to other Python process.
3. Extracted a new class `ComposeEfilesUpdater` without the `retrieve` field
4. Removed logic with the `t_log: TimeLogger` field. It seems, currently the field isn't used outside. And to measure time/clicks properly (for concurrent processes) the `TimeLogger` class should be extended.