### PR TITLE
Run tasks on thread and process pools

### DIFF
--- a/composer/aws/efile/filings.py
+++ b/composer/aws/efile/filings.py
@@ -112,9 +112,12 @@ def _xml_to_json(changes: List[Tuple[str, Dict[str, FilingMetadata]]], xml_cache
         (ein, updates) = change
         for filing_md in updates.values():
             irs_efile_id: str = filing_md.irs_efile_id
-            xml_path: str = os.path.join(_ein_path(xml_cache_dir, ein), "%s_public.xml" % irs_efile_id)
+            xml_path: str = os.path.join(_ein_path(xml_cache_dir, ein), "%s_public_1.xml" % irs_efile_id)
             json_path: str = os.path.join(_ein_path(json_cache_dir, ein), "%s.json" % irs_efile_id)
-            with open(xml_path) as xml_fh, open(json_path, "w") as json_fh:
-                raw_xml: str = xml_fh.read()
-                as_json: Dict = translate(raw_xml)
-                json.dump(as_json, json_fh)
+            try:
+                with open(xml_path) as xml_fh, open(json_path, "w") as json_fh:
+                    raw_xml: str = xml_fh.read()
+                    as_json: Dict = translate(raw_xml)
+                    json.dump(as_json, json_fh)
+            except FileNotFoundError as e:
+                logging.warning(e)

--- a/composer/aws/efile/filings.py
+++ b/composer/aws/efile/filings.py
@@ -4,15 +4,18 @@ import os
 import random
 import shutil
 import string
-from concurrent.futures.process import ProcessPoolExecutor
-from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Iterator
+from typing import Iterator, List, Optional
 
-from composer.aws.s3 import Bucket, Tuple, Dict, Iterable
+from botocore.exceptions import ClientError
+
+from composer.aws.efile.bucket import efile_bucket
+from composer.aws.s3 import Tuple, Dict, Iterable, Bucket
 from composer.efile.structures.metadata import FilingMetadata
 from functools import lru_cache
 
 from composer.efile.xmlio import JsonTranslator
+from composer.futures import run_on_process_pool, run_on_thread_pool
+
 
 @lru_cache(maxsize=4194304)
 def _ein_path(basepath: str, ein: str) -> str:
@@ -44,10 +47,9 @@ class RetrieveEfiles:
     """Download any new e-files as XML from S3 and store them in a temporary directory. Convert them to JSON files, also
     stored in a temporary directory. Yield a map of EIN -> (map of period -> JSON file path)."""
 
-    def __init__(self, bucket: Bucket, tmp_base: str = "/tmp", no_cleanup: bool=False):
+    def __init__(self, bucket: Bucket, tmp_base: str = "/tmp", no_cleanup: bool = False):
         self.bucket: Bucket = bucket
-        self.translate = JsonTranslator()
-        self.xml_cache_dir: str = _tmpdir(tmp_base)     # Official temp directory package makes things too hard
+        self.xml_cache_dir: str = _tmpdir(tmp_base)  # Official temp directory package makes things too hard
         self.json_cache_dir: str = _tmpdir(tmp_base)
         self.no_cleanup: bool = no_cleanup
 
@@ -64,34 +66,14 @@ class RetrieveEfiles:
     def _convert_all(self, changes: Iterable[Tuple[str, Dict[str, FilingMetadata]]]):
         """Convert all XML files into JSON files. CPU-bound, so process pool."""
         logging.info("Converting XML to JSON.")
-        with ProcessPoolExecutor() as executor:
-            for ein, updates in changes:
-                for filing_md in updates.values():
-                    irs_efile_id: str = filing_md.irs_efile_id
-                    future = executor.submit(self._xml_to_json(ein, irs_efile_id))
-
-    def _xml_to_json(self, ein: str, irs_efile_id: str) -> None:
-        xml_path: str = os.path.join(_ein_path(self.xml_cache_dir, ein), "%s_public.xml" % irs_efile_id)
-        json_path: str = os.path.join(_ein_path(self.json_cache_dir, ein), "%s.json" % irs_efile_id)
-        with open(xml_path) as xml_fh, open(json_path, "w") as json_fh:
-            raw_xml: str = xml_fh.read()
-            as_json: Dict = self.translate(raw_xml)
-            json.dump(as_json, json_fh)
-
-    def _download_xml(self, target: Tuple[str, str]):
-        ein_path, irs_efile_id = target  # types: str, str
-        s3_key: str = "%s_public.xml" % irs_efile_id
-        destination: str = os.path.join(ein_path, s3_key)
-        with open(destination, "w") as fh:
-            raw_xml: str = self.bucket.get_obj_body(s3_key)
-            fh.write(raw_xml)
+        run_on_process_pool(_xml_to_json, list(changes), self.xml_cache_dir, self.json_cache_dir)
 
     def _download_all(self, changes: Iterable[Tuple[str, Dict[str, FilingMetadata]]]):
         """Download all XML files to local storage. I/O-bound, so thread pool."""
         logging.info("Downloading new XML files.")
-        with ThreadPoolExecutor() as executor:
-            targets: Iterator[Tuple[str, str]] = _get_download_targets(changes, self.xml_cache_dir)
-            executor.map(self._download_xml, targets)
+        targets: List[Tuple[str, str]] = list(_get_download_targets(changes, self.xml_cache_dir))
+        # run_on_process_pool(_download_xml, targets, None)
+        run_on_thread_pool(_download_xml, targets, self.bucket, workers_count=os.cpu_count()*10)
 
     def __call__(self, changes: Iterable[Tuple[str, Dict[str, FilingMetadata]]]) \
             -> Iterator[Tuple[str, Dict[str, str]]]:
@@ -103,3 +85,34 @@ class RetrieveEfiles:
         if not self.no_cleanup:
             shutil.rmtree(self.xml_cache_dir, ignore_errors=True)
             shutil.rmtree(self.json_cache_dir, ignore_errors=True)
+
+
+def _download_xml(targets: List[Tuple[str, str]], bucket: Optional[Bucket]):
+    bucket = bucket or efile_bucket()
+    total_size = 0
+    for target in targets:
+        ein_path, irs_efile_id = target  # types: str, str
+        s3_key: str = "%s_public.xml" % irs_efile_id
+        try:
+            raw_xml: str = bucket.get_obj_body(s3_key)
+        except ClientError as e:
+            logging.warning("can't get object by key '%s': %s", s3_key, e)
+            continue
+        destination: str = os.path.join(ein_path, s3_key)
+        with open(destination, "w") as fh:
+            total_size += len(raw_xml.encode("utf-8"))
+            fh.write(raw_xml)
+
+
+def _xml_to_json(changes: List[Tuple[str, Dict[str, FilingMetadata]]], xml_cache_dir: str, json_cache_dir: str) -> None:
+    translate = JsonTranslator()
+    for change in changes:
+        (ein, updates) = change
+        for filing_md in updates.values():
+            irs_efile_id: str = filing_md.irs_efile_id
+            xml_path: str = os.path.join(_ein_path(xml_cache_dir, ein), "%s_public.xml" % irs_efile_id)
+            json_path: str = os.path.join(_ein_path(json_cache_dir, ein), "%s.json" % irs_efile_id)
+            with open(xml_path) as xml_fh, open(json_path, "w") as json_fh:
+                raw_xml: str = xml_fh.read()
+                as_json: Dict = translate(raw_xml)
+                json.dump(as_json, json_fh)

--- a/composer/efile/compose.py
+++ b/composer/efile/compose.py
@@ -1,17 +1,17 @@
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Iterator, Tuple, Dict, List, Iterable
+from typing import Iterator, Tuple, Dict, List
 import json
-
-from concurrent.futures import Future, as_completed, ProcessPoolExecutor
 
 from composer.aws.efile.filings import RetrieveEfiles
 from composer.aws.s3 import Bucket
 from composer.efile.structures.metadata import FilingMetadata
 from composer.fileio.paths import EINPathManager
+from composer.futures import run_on_process_pool
 
 TEMPLATE = "%s.json"
+
 
 @dataclass
 class ComposeEfiles(Callable):
@@ -24,16 +24,9 @@ class ComposeEfiles(Callable):
         path_mgr: EINPathManager = EINPathManager(basepath)
         return cls(retrieve, path_mgr)
 
-    def process_all(self, json_changes: Iterable[Tuple[str, Dict[str, str]]]):
+    def process_all(self, json_changes: List[Tuple[str, Dict[str, str]]]):
         updater = ComposeEfilesUpdater(self.path_mgr)
-        exceptions = []
-        with ProcessPoolExecutor() as executor:
-            futures = [executor.submit(updater.create_or_update, change) for change in json_changes]
-            for future in as_completed(futures):
-                if future.exception() is not None:
-                    exceptions.append(future.exception())
-        if len(exceptions) > 0:
-            raise exceptions[0]
+        run_on_process_pool(updater.create_or_update, json_changes)
 
     def __call__(self, changes: Iterator[Tuple[str, Dict[str, FilingMetadata]]]):
         """Iterate over EINs flagged as having one or more new e-files since the last update. For each one, create or
@@ -42,7 +35,7 @@ class ComposeEfiles(Callable):
         :param changes: Iterator of (EIN, dictionary of (filing period -> Filing)).
         """
         change_list: List = list(changes)
-        json_changes: Iterable[Tuple[str, Dict[str, str]]] = list(self.retrieve(change_list))
+        json_changes: List[Tuple[str, Dict[str, str]]] = list(self.retrieve(change_list))
         logging.info("Updating e-file composites.")
 
         self.process_all(json_changes)
@@ -59,12 +52,13 @@ class ComposeEfilesUpdater:
         except FileNotFoundError:
             return {}
 
-    def create_or_update(self, change: Tuple[str, Dict[str, str]]):
-        ein, updates = change
-        composite: Dict = self._get_existing(ein)
-        for period, json_path in updates.items():
-            with open(json_path) as fh:
-                content: Dict = json.load(fh)
-            composite[period] = content
-        with self.path_mgr.open_for_writing(ein, TEMPLATE) as fh:
-            json.dump(composite, fh, indent=2)
+    def create_or_update(self, changes: List[Tuple[str, Dict[str, str]]]):
+        for change in changes:
+            ein, updates = change
+            composite: Dict = self._get_existing(ein)
+            for period, json_path in updates.items():
+                with open(json_path) as fh:
+                    content: Dict = json.load(fh)
+                composite[period] = content
+            with self.path_mgr.open_for_writing(ein, TEMPLATE) as fh:
+                json.dump(composite, fh, indent=2)

--- a/composer/efile/compose.py
+++ b/composer/efile/compose.py
@@ -57,8 +57,11 @@ class ComposeEfilesUpdater:
             ein, updates = change
             composite: Dict = self._get_existing(ein)
             for period, json_path in updates.items():
-                with open(json_path) as fh:
-                    content: Dict = json.load(fh)
-                composite[period] = content
+                try:
+                    with open(json_path) as fh:
+                        content: Dict = json.load(fh)
+                    composite[period] = content
+                except FileNotFoundError as e:
+                    logging.warning(e)
             with self.path_mgr.open_for_writing(ein, TEMPLATE) as fh:
                 json.dump(composite, fh, indent=2)

--- a/composer/efile/compose.py
+++ b/composer/efile/compose.py
@@ -19,8 +19,8 @@ class ComposeEfiles(Callable):
     path_mgr: EINPathManager
 
     @classmethod
-    def build(cls, basepath: str, bucket: Bucket, temp_path: str, no_cleanup: bool) -> "ComposeEfiles":
-        retrieve: RetrieveEfiles = RetrieveEfiles(bucket, temp_path, no_cleanup)
+    def build(cls, basepath: str, temp_path: str, no_cleanup: bool) -> "ComposeEfiles":
+        retrieve: RetrieveEfiles = RetrieveEfiles(temp_path, no_cleanup)
         path_mgr: EINPathManager = EINPathManager(basepath)
         return cls(retrieve, path_mgr)
 

--- a/composer/efile/update.py
+++ b/composer/efile/update.py
@@ -22,7 +22,7 @@ class UpdateEfileState(Callable):
     def build(cls, basepath: str, temp_path: str, no_cleanup: bool) -> "UpdateEfileState":
         bucket: Bucket = efile_bucket()
         indices: EfileIndices = EfileIndices(bucket)
-        compose: ComposeEfiles = ComposeEfiles.build(basepath, bucket, temp_path, no_cleanup)
+        compose: ComposeEfiles = ComposeEfiles.build(basepath, temp_path, no_cleanup)
         return cls(basepath, indices, compose)
 
     def _connect(self) -> Connection:

--- a/composer/futures.py
+++ b/composer/futures.py
@@ -1,0 +1,52 @@
+import math
+import os
+from concurrent.futures import as_completed, Executor, ThreadPoolExecutor
+from concurrent.futures.process import ProcessPoolExecutor
+from typing import Optional, Callable, List, Any, Iterable
+
+
+def run_on_process_pool(func: Callable, items: List[Any], *args: Any, chunk_size: Optional[int] = None, workers_count: Optional[int] = None):
+    if len(items) == 0:
+        return
+
+    if workers_count is None:
+        workers_count = os.cpu_count() or 1
+
+    if chunk_size is None:
+        chunk_size = math.ceil(len(items) / workers_count)
+
+    executor = ProcessPoolExecutor(max_workers=workers_count)
+    run_on_pool(executor, func, items, *args, chunk_size=chunk_size)
+
+
+def run_on_thread_pool(func: Callable, items: List[Any], *args: Any, chunk_size: Optional[int] = None, workers_count: Optional[int] = None):
+    if len(items) == 0:
+        return
+
+    executor = ThreadPoolExecutor(max_workers=workers_count)
+    run_on_pool(executor, func, items, *args, chunk_size=chunk_size)
+
+
+def run_on_pool(executor: Executor, func: Callable, items: List[Any], *args: Any, chunk_size: Optional[int] = None):
+    if len(items) == 0:
+        return
+
+    if chunk_size is None:
+        chunk_size = 1
+
+    chunks: Iterable[List[Any]] = _split_to_chunks(list(items), chunk_size)
+
+    exceptions = []
+    with executor:
+        futures = [executor.submit(func, chunk, *args) for chunk in chunks]
+        for future in as_completed(futures):
+            if future.exception() is not None:
+                exceptions.append(future.exception())
+    if len(exceptions) > 0:
+        raise exceptions[0]
+
+
+# https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks
+def _split_to_chunks(items: List[Any], chunk_size: int) -> Iterable[List[Any]]:
+    for i in range(0, len(items), chunk_size):
+        yield items[i:i + chunk_size]

--- a/test/test_functional/test_update_efile.py
+++ b/test/test_functional/test_update_efile.py
@@ -33,9 +33,7 @@ def make_indices(timepoint: str) -> EfileIndices:
     return indices
 
 def make_compose(tp_path: str) -> ComposeEfiles:
-    efile_xml_path: str = os.path.join(fixture_path, "efile_xml")
-    xml_bucket: Bucket = file_backed_bucket(efile_xml_path)
-    retrieve: RetrieveEfiles = RetrieveEfiles(xml_bucket)
+    retrieve: RetrieveEfiles = RetrieveEfiles()
     path_mgr: EINPathManager = EINPathManager(tp_path)
     compose: ComposeEfiles = ComposeEfiles(retrieve, path_mgr)
     return compose
@@ -45,6 +43,12 @@ def do_update(timepoint: str, tp_path: str):
     compose: ComposeEfiles = make_compose(tp_path)
     update: UpdateEfileState = UpdateEfileState(tp_path, indices, compose)
     update()
+
+def get_bucket():
+    efile_xml_path: str = os.path.join(fixture_path, "efile_xml")
+    return file_backed_bucket(efile_xml_path)
+
+RetrieveEfiles.get_bucket = get_bucket
 
 """Run the initial update -- no data exists"""
 os.makedirs(tp1_path)


### PR DESCRIPTION
Extracted run_on_process_pool and run_on_thread_pool functions.
Resolved pickling errors when _convert_all starts to use ProcessPoolExecutor